### PR TITLE
Implement scale encode/decode for ExecutionResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### [0.6.0] - 2023-6-18
 
+* add feature-enabled `Encode` / `Decode` (parity-scale) implementations for the `ExecutionResources` struct
+
 * fix: `dibit` hint no longer fails when called with an `m` of zero [#1247](https://github.com/lambdaclass/cairo-rs/pull/1247)
 
 * fix(security): avoid denial of service on malicious input exploiting the scientific notation parser [#1239](https://github.com/lambdaclass/cairo-rs/pull/1239)

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -30,6 +30,7 @@ cairo-1-hints = [
 test_utils = [
     "skip_next_instruction_hint",
     "hooks",
+    "parity-scale-codec",
 ] # This feature will reference every test-oriented feature
 skip_next_instruction_hint = []
 hooks = []

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1195,13 +1195,18 @@ impl MulAssign<usize> for ExecutionResources {
 #[cfg(feature = "parity-scale-codec")]
 impl Encode for ExecutionResources {
     fn size_hint(&self) -> usize {
-        8 + 8
-            + 8  // counter size
-            + self
-                .builtin_instance_counter
-                .iter()
-                .map(|(k, _)| k.size_hint() + 8)
-                .sum::<usize>()
+        let n_steps_sz = crate::stdlib::mem::size_of::<u64>();
+        let n_memory_holes_sz = crate::stdlib::mem::size_of::<u64>();
+        // There is at most one entry per builtin.
+        // Most likely there won't be more than 31 builtins.
+        // Currently there are 9 of them
+        let n_counters_sz = crate::stdlib::mem::size_of::<u8>();
+        let counters_map_sz = self
+            .builtin_instance_counter
+            .iter()
+            .map(|(k, _)| k.size_hint() + 8)
+            .sum::<usize>();
+        n_steps_sz + n_memory_holes_sz + n_counters_sz + counters_map_sz
     }
 
     fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1203,8 +1203,8 @@ impl Encode for ExecutionResources {
         let n_counters_sz = crate::stdlib::mem::size_of::<u8>();
         let counters_map_sz = self
             .builtin_instance_counter
-            .iter()
-            .map(|(k, _)| k.size_hint() + 8)
+            .keys()
+            .map(|k| k.size_hint() + crate::stdlib::mem::size_of::<u64>())
             .sum::<usize>();
         n_steps_sz + n_memory_holes_sz + n_counters_sz + counters_map_sz
     }


### PR DESCRIPTION
Required to derive scale codec for `CallInfo` struct in blockifier:
https://github.com/keep-starknet-strange/blockifier/pull/9

