### PR TITLE
refactor: added an extra HashMap to BTreeMap conversion step

### DIFF
--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -6,12 +6,10 @@
 //! To generate a [`Program`] from a JSON string, see [`Program::from_bytes()`].
 //! To do the same from a JSON file, see [`Program::from_file()`].
 
-use crate::stdlib::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    prelude::*,
-    sync::Arc,
-};
+extern crate alloc;
+pub use alloc::collections::btree_map::BTreeMap;
+
+use crate::stdlib::{collections::HashMap, fmt, prelude::*, sync::Arc};
 
 use super::serialize_program::serialize_value_address;
 use crate::vm::runners::builtin_runner::SEGMENT_ARENA_BUILTIN_NAME;
@@ -115,7 +113,7 @@ impl Encode for FlowTrackingData {
             .reference_ids
             .iter()
             .map(|(s, v)| (s.clone(), *v as u64))
-            .collect::<Vec<_>>();
+            .collect::<BTreeMap<String, u64>>();
 
         parity_scale_codec::Encode::encode_to(&self.ap_tracking, dest);
         parity_scale_codec::Encode::encode_to(&reference_ids, dest);
@@ -133,7 +131,7 @@ impl Decode for FlowTrackingData {
         let ap_tracking = <ApTracking as Decode>::decode(input)
             .map_err(|e| e.chain("Could not decode `FlowTrackingData::ap_tracking`"))?;
 
-        let reference_ids = <Vec<(String, u64)> as Decode>::decode(input)
+        let reference_ids = <BTreeMap<String, u64> as Decode>::decode(input)
             .map_err(|e| e.chain("Could not decode `FlowTrackingData::reference_ids`"))?
             .into_iter()
             .map(|(s, v)| (s, v as usize))
@@ -236,7 +234,8 @@ pub struct Identifier {
 impl Encode for Identifier {
     fn encode(&self) -> Vec<u8> {
         let val = self.clone();
-        let members: Option<Vec<(String, Member)>> = val.members.map(|m| m.into_iter().collect());
+        let members: Option<BTreeMap<String, Member>> =
+            val.members.map(|m| m.into_iter().collect());
         (
             val.pc.map(|v| v as u64),
             val.type_,
@@ -266,7 +265,7 @@ impl Decode for Identifier {
             Option<String>,
             Option<Felt252>,
             Option<String>,
-            Option<Vec<(String, Member)>>,
+            Option<BTreeMap<String, Member>>,
             Option<String>,
             Option<Vec<String>>,
             Option<u64>,

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -120,7 +120,7 @@ impl Encode for SharedProgramData {
             .identifiers
             .iter()
             .map(|(s, i)| (s.clone(), i.clone()))
-            .collect::<Vec<(String, Identifier)>>();
+            .collect::<BTreeMap<String, Identifier>>();
 
         parity_scale_codec::Encode::encode_to(&self.data, dest);
         parity_scale_codec::Encode::encode_to(&hints, dest);
@@ -177,7 +177,7 @@ impl Decode for SharedProgramData {
                     .collect::<HashMap<_, _>>()
             });
 
-        let identifiers = <Vec<(String, Identifier)> as Decode>::decode(input)
+        let identifiers = <BTreeMap<String, Identifier> as Decode>::decode(input)
             .map_err(|e| e.chain("Could not decode `SharedProgramData::identifiers`"))?
             .into_iter()
             .collect::<HashMap<String, Identifier>>();
@@ -220,7 +220,7 @@ impl Encode for Program {
             .constants
             .iter()
             .map(|(s, f)| (s.clone(), f.clone()))
-            .collect::<Vec<(String, Felt252)>>();
+            .collect::<BTreeMap<String, Felt252>>();
 
         parity_scale_codec::Encode::encode_to(&self.shared_program_data, dest);
         parity_scale_codec::Encode::encode_to(&constants, dest);
@@ -238,7 +238,7 @@ impl Decode for Program {
     ) -> Result<Self, parity_scale_codec::Error> {
         let shared_program_data = <Arc<SharedProgramData> as Decode>::decode(input)
             .map_err(|e| e.chain("Could not decode `Program::shared_program_data`"))?;
-        let constants = <Vec<(String, Felt252)> as Decode>::decode(input)
+        let constants = <BTreeMap<String, Felt252> as Decode>::decode(input)
             .map_err(|e| e.chain("Could not decode `Program::constants`"))?
             .into_iter()
             .collect::<HashMap<_, _>>();

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+pub use alloc::collections::btree_map::BTreeMap;
+
 use crate::{
     air_public_input::{PublicInput, PublicInputError},
     stdlib::{
@@ -45,6 +48,7 @@ use crate::{
         },
     },
 };
+
 use felt::Felt252;
 use num_integer::div_rem;
 use num_traits::Zero;
@@ -1265,7 +1269,7 @@ impl Encode for ExecutionResources {
     fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
         Encode::encode_to(&(self.n_steps as u64), dest);
         Encode::encode_to(&(self.n_memory_holes as u64), dest);
-        let builtin_instance_counter: Vec<(String, u64)> = self
+        let builtin_instance_counter: BTreeMap<String, u64> = self
             .builtin_instance_counter
             .clone()
             .into_iter()
@@ -1282,10 +1286,11 @@ impl Decode for ExecutionResources {
     ) -> Result<Self, parity_scale_codec::Error> {
         let n_steps = u64::decode(input)? as usize;
         let n_memory_holes = u64::decode(input)? as usize;
-        let builtin_instance_counter: HashMap<String, usize> = Vec::<(String, u64)>::decode(input)?
-            .into_iter()
-            .map(|(k, v)| (k, v as usize))
-            .collect();
+        let builtin_instance_counter: HashMap<String, usize> =
+            BTreeMap::<String, u64>::decode(input)?
+                .into_iter()
+                .map(|(k, v)| (k, v as usize))
+                .collect();
         Ok(Self {
             n_steps,
             n_memory_holes,


### PR DESCRIPTION
#BugFix

HashMap can be unpredictable when we encode/decode it within the Substrate runtime, so to always get the same order and result, we convert it to BTreeMap and then encode.

Solves [this](https://github.com/keep-starknet-strange/madara/issues/1054)