### PR TITLE
fix(ProgramJson): :bug: Removed compiler_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: removed `compiler_version` field from `ProgramJson` in `vm/src/serde/deserialize_program.rs` as it was no longer used and causing deserialization issues.
+
 * feat: make *arbitrary* feature also enable a `proptest::arbitrary::Arbitrary` implementation for `Felt252` [#1355](https://github.com/lambdaclass/cairo-vm/pull/1355)
 
 * fix: correctly display invalid signature error message [#1361](https://github.com/lambdaclass/cairo-vm/pull/1361)

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -39,10 +39,8 @@ mod stdlib {
             borrow::ToOwned,
             boxed::Box,
             clone::Clone,
-            cmp::{Eq, PartialEq, Reverse},
-            fmt,
+            cmp::{Eq, PartialEq},
             iter::IntoIterator,
-            str::FromStr,
             string::{String, ToString},
             vec::Vec,
         };

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -87,7 +87,6 @@ pub struct ProgramJson {
     pub attributes: Vec<Attribute>,
     pub debug_info: Option<DebugInfo>,
     pub main_scope: String,
-    pub compiler_version: String,
 }
 
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(Arbitrary))]
@@ -880,7 +879,6 @@ pub fn parse_program(program: Program) -> ProgramJson {
                 instruction_locations,
             }),
         main_scope: String::default(),
-        compiler_version: String::default(),
     }
 }
 

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -1119,7 +1119,6 @@ mod tests {
             {
                 "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
                 "main_scope": "__main__",
-                "compiler_version": "0.11.0",
                 "attributes": [],
                 "debug_info": {
                     "instruction_locations": {}
@@ -1685,7 +1684,6 @@ mod tests {
             {
                 "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
                 "main_scope": "__main__",
-                "compiler_version": "0.11.0",
                 "attributes": [],
                 "debug_info": {
                     "instruction_locations": {}
@@ -1785,8 +1783,7 @@ mod tests {
                     "references": [
                     ]
                 },
-                "main_scope": "__main__",
-                "compiler_version": "0.11.0"
+                "main_scope": "__main__"
             }"#;
 
         let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
@@ -1902,8 +1899,7 @@ mod tests {
                     "references": [
                     ]
                 },
-                "main_scope": "__main__",
-                "compiler_version": "0.11.0"
+                "main_scope": "__main__"
             }"#;
 
         let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
@@ -2009,8 +2005,7 @@ mod tests {
                     "references": [
                     ]
                 },
-                "main_scope": "__main__",
-                "compiler_version": "0.11.0"
+                "main_scope": "__main__"
             }"#;
 
         let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();


### PR DESCRIPTION
# Removed field `compiler_version` in [`ProgramJson`](https://github.com/keep-starknet-strange/cairo-rs/blob/53dfed63ce010e9de8fb39e31f96b3034682762d/vm/src/serde/deserialize_program.rs#L76C12-L76C23)

## Description

This is in accordance with changes made further upstream on the `main` branch, where `compiler_version` has been removed. `compiler_version` was not used anyway and was creating issues when deserializing Cario v0 classes which did not include it. Notably this was also issues with libraries such as starknet-rs which consider `compiler_version` as an [optional parameter](https://github.com/xJonathanLEI/starknet-rs/blob/49719f49a18f9621fc37342959e84900b600083e/starknet-core/src/types/contract/legacy.rs#L500) when compressing cairo v0 classes from JSON.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

